### PR TITLE
Fix: Tips not updating when location changes

### DIFF
--- a/src/hooks/queries/location/use-location.ts
+++ b/src/hooks/queries/location/use-location.ts
@@ -115,7 +115,8 @@ export const useUserLocation = () => {
             q.queryKey[0] === "toxicFishData" ||
             q.queryKey[0] === "weather" ||
             q.queryKey[0] === "categoryRepresentativeImages" ||
-            q.queryKey[0] === "browseFish"),
+            q.queryKey[0] === "browseFish" ||
+            q.queryKey[0] === "fishingTips"),
       });
     },
   });
@@ -151,7 +152,8 @@ export const useUserLocation = () => {
             q.queryKey[0] === "toxicFishData" ||
             q.queryKey[0] === "weather" ||
             q.queryKey[0] === "categoryRepresentativeImages" ||
-            q.queryKey[0] === "browseFish"),
+            q.queryKey[0] === "browseFish" ||
+            q.queryKey[0] === "fishingTips"),
       });
     },
   });


### PR DESCRIPTION
# Fix: Tips not updating when location changes

## Overview
When the user changes their location in the app, fishing tips on the home page were not updating and continued to show tips for the previous location. This PR fixes that by invalidating the fishing tips query when location is updated or refreshed.

**Key Changes:**
- Invalidate \`fishingTips\` query in \`updateLocationMutation.onSuccess\`
- Invalidate \`fishingTips\` query in \`refreshLocationMutation.onSuccess\`

## Technical Changes

**Frontend:**
- \`src/hooks/queries/location/use-location.ts\`: Added \`q.queryKey[0] === "fishingTips"\` to the predicate in both location mutation success handlers so tips refetch when location changes (same pattern as existing \`fishDataInfinite\`, \`weather\`, etc.).

**Backend:**
- None. Tips are already served based on the authenticated user profile; the backend did not need changes.

## Dependencies
N/A - No new dependencies added

## Testing
- [ ] Change location via the location modal or weather screen
- [ ] Confirm the fishing tips carousel on the home page updates to show tips for the new location
- [ ] Confirm existing location-dependent data (weather, fish, etc.) still updates as before
