### PR TITLE
Add /support page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ const SettingsPage = lazy(() => import("./components/settings-page"));
 const FaqPage = lazy(() => import("./components/faq-page"));
 const TermsPage = lazy(() => import("./pages/terms"));
 const PrivacyPolicyPage = lazy(() => import("./pages/privacy-policy"));
+const SupportPage = lazy(() => import("./pages/support"));
 const BlobConnectionTest = lazy(
   () => import("./components/blob-connection-test"),
 );
@@ -131,6 +132,7 @@ function AppContent() {
     "/home",
     ROUTES.PRIVACY_POLICY,
     ROUTES.TERMS,
+    ROUTES.SUPPORT,
   ].includes(location.pathname);
 
   const is404Page =
@@ -263,6 +265,14 @@ const router = createBrowserRouter(
       element: (
         <AppWrapper>
           <PrivacyPolicyPage />
+        </AppWrapper>
+      ),
+    },
+    {
+      path: ROUTES.SUPPORT,
+      element: (
+        <AppWrapper>
+          <SupportPage />
         </AppWrapper>
       ),
     },

--- a/src/lib/routing.ts
+++ b/src/lib/routing.ts
@@ -19,6 +19,7 @@ export const ROUTES = {
   FAQ: "/faq",
   TERMS: "/terms",
   PRIVACY_POLICY: "/privacy-policy",
+  SUPPORT: "/support",
   MY_GEAR: "/my-gear",
   GEAR_DETAIL: "/gear-detail/:gearId",
   GEAR_CATEGORY: "/gear-category",

--- a/src/pages/support/index.tsx
+++ b/src/pages/support/index.tsx
@@ -1,0 +1,206 @@
+import React from "react";
+import LandingPageLayout, {
+  LandingPageHeader,
+} from "@/components/layout/landing-page-layout";
+
+const SupportPage: React.FC = () => {
+  return (
+    <LandingPageLayout>
+      <div className="relative w-full">
+        <LandingPageHeader
+          isMobileMenuOpen={false}
+          setIsMobileMenuOpen={() => {}}
+        />
+      </div>
+      <div className="flex mt-20 bg-black mb-10 flex-col">
+        {/* Main Content */}
+        <div className="max-w-3xl mx-auto w-full">
+          <div className="px-4 md:px-0 space-y-6">
+            <div className="flex items-center">
+              <h1 className="text-6xl font-bold font-[serif] text-white">
+                Support
+              </h1>
+            </div>
+            <div className="space-y-4">
+              <p className="text-white/70 leading-relaxed text-lg">
+                Stuck on something? Got a feature request, a bug report, or just
+                want to tell us what&apos;s working? Write in. Replies usually
+                come within a day.
+              </p>
+            </div>
+
+            {/* Contact cards */}
+            <div className="space-y-4 pt-2">
+              <div className="border border-white/10 rounded-xl p-5">
+                <h3 className="text-md font-semibold text-white mb-1">Email</h3>
+                <a
+                  href="mailto:info@lishka.app"
+                  className="text-white/80 hover:text-white underline"
+                >
+                  info@lishka.app
+                </a>
+              </div>
+              <div className="border border-white/10 rounded-xl p-5">
+                <h3 className="text-md font-semibold text-white mb-1">
+                  Privacy + legal
+                </h3>
+                <a
+                  href="mailto:legal@lishka.app"
+                  className="text-white/80 hover:text-white underline"
+                >
+                  legal@lishka.app
+                </a>
+              </div>
+            </div>
+
+            {/* FAQ */}
+            <div className="space-y-4 pt-6">
+              <h2 className="text-lg font-semibold text-white">
+                Common questions
+              </h2>
+
+              <details className="border-t border-white/10 py-3">
+                <summary className="text-white font-medium cursor-pointer">
+                  Why does my &quot;Good window&quot; badge disappear when
+                  conditions get rough?
+                </summary>
+                <p className="text-white/70 leading-relaxed mt-2">
+                  Lishka&apos;s score combines biology (whether fish are
+                  feeding) with conditions (whether you can safely fish). If
+                  wind, gusts, or waves cross the safety threshold for your
+                  method, the score drops into the &quot;Tough&quot; band and a
+                  &quot;Too risky&quot; badge appears. The number itself varies
+                  inside that band based on how bad the conditions are.
+                </p>
+              </details>
+
+              <details className="border-t border-white/10 py-3">
+                <summary className="text-white font-medium cursor-pointer">
+                  The forecast said &quot;Peak window&quot; but the actual
+                  conditions were different. What happened?
+                </summary>
+                <p className="text-white/70 leading-relaxed mt-2">
+                  Forecasts can be wrong. Lishka pulls weather, marine, and tide
+                  data from external providers, and weather models are imperfect
+                  (especially 5+ days out). Lishka is a planning tool, not a
+                  safety system. Always verify local conditions, weather, and
+                  tide before going on the water.
+                </p>
+              </details>
+
+              <details className="border-t border-white/10 py-3">
+                <summary className="text-white font-medium cursor-pointer">
+                  I uploaded a photo and the species identification is wrong.
+                  Can I fix it?
+                </summary>
+                <p className="text-white/70 leading-relaxed mt-2">
+                  Tap the catch, then edit the species name. The AI is a
+                  starting point, not the final word. Many fish have very
+                  similar appearances and the model can confuse close relatives.
+                </p>
+              </details>
+
+              <details className="border-t border-white/10 py-3">
+                <summary className="text-white font-medium cursor-pointer">
+                  How do I enable notifications?
+                </summary>
+                <p className="text-white/70 leading-relaxed mt-2">
+                  Profile → Notifications inside the app. If you previously
+                  declined the iOS permission, you&apos;ll need to enable it in
+                  iOS Settings → Lishka → Notifications first.
+                </p>
+              </details>
+
+              <details className="border-t border-white/10 py-3">
+                <summary className="text-white font-medium cursor-pointer">
+                  How do I change my fishing method or boat size?
+                </summary>
+                <p className="text-white/70 leading-relaxed mt-2">
+                  On the home tab, tap the chip at the top showing your current
+                  method and session length. The score recalculates immediately.
+                </p>
+              </details>
+
+              <details className="border-t border-white/10 py-3">
+                <summary className="text-white font-medium cursor-pointer">
+                  How do I delete my account?
+                </summary>
+                <p className="text-white/70 leading-relaxed mt-2">
+                  Profile → Settings → Delete Account. Your data is removed
+                  within 30 days. See the{" "}
+                  <a href="/privacy-policy" className="text-white underline">
+                    Privacy Policy
+                  </a>{" "}
+                  for details.
+                </p>
+              </details>
+
+              <details className="border-t border-white/10 py-3">
+                <summary className="text-white font-medium cursor-pointer">
+                  Does Lishka work outside Europe?
+                </summary>
+                <p className="text-white/70 leading-relaxed mt-2">
+                  Yes. Forecasts work anywhere Open-Meteo provides marine and
+                  weather data, which is effectively worldwide. Some regions
+                  have more accurate local-model coverage than others.
+                </p>
+              </details>
+
+              <details className="border-t border-white/10 py-3 border-b">
+                <summary className="text-white font-medium cursor-pointer">
+                  Is my data shared with anyone?
+                </summary>
+                <p className="text-white/70 leading-relaxed mt-2">
+                  We don&apos;t sell or share your personal data with
+                  advertisers. Photos you upload are sent to OpenAI for species
+                  identification. Weather and tide providers receive only
+                  latitude and longitude, no personal identifiers. Full
+                  breakdown in the{" "}
+                  <a href="/privacy-policy" className="text-white underline">
+                    Privacy Policy
+                  </a>
+                  .
+                </p>
+              </details>
+            </div>
+
+            <div className="space-y-4 pt-6">
+              <h2 className="text-lg font-semibold text-white">
+                Reporting a bug
+              </h2>
+              <p className="text-white/70 leading-relaxed">
+                When you write in, the details that help most are:
+              </p>
+              <ul className="list-disc list-inside text-white/70 space-y-2 ml-4">
+                <li>Your device model and iOS / Android version</li>
+                <li>What you were doing when it happened</li>
+                <li>What you expected to see vs what you actually saw</li>
+                <li>A screenshot or screen recording, if you can</li>
+              </ul>
+            </div>
+
+            <div className="space-y-4 pt-6 pb-10">
+              <h2 className="text-lg font-semibold text-white">
+                Reporting inappropriate content
+              </h2>
+              <p className="text-white/70 leading-relaxed">
+                Lishka stores user-uploaded photos privately. They&apos;re never
+                shown to other users. If you ever come across content in the app
+                that you believe shouldn&apos;t be there, write to{" "}
+                <a
+                  href="mailto:legal@lishka.app"
+                  className="text-white underline"
+                >
+                  legal@lishka.app
+                </a>{" "}
+                and we&apos;ll investigate within 24 hours.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </LandingPageLayout>
+  );
+};
+
+export default SupportPage;


### PR DESCRIPTION
## Summary
Adds a Support page at \`/support\` so Apple's required Support URL for App Store submission resolves to a working page.

## What's on the page
- Contact emails (info@lishka.app, legal@lishka.app)
- 8-question FAQ covering: the new scoring system, forecast accuracy, AI species ID, enabling notifications, changing fishing method, account deletion, geographic coverage, data sharing
- Bug-reporting guidance
- Content-reporting instructions

Matches the existing \`LandingPageLayout\` dark-themed pattern used by \`/terms\` and \`/privacy-policy\`.

## Test plan
- [ ] Vercel preview deploy renders \`/support\` without errors
- [ ] After merge, hit \`https://lishka.app/support\` — page resolves
- [ ] Email links (\`mailto:info@lishka.app\`, \`mailto:legal@lishka.app\`) open the mail client
- [ ] Embedded links to \`/privacy-policy\` work

## Context
This unblocks Apple App Store submission — see [TonnaClayton/lishka-mobile#61](https://github.com/TonnaClayton/lishka-mobile/pull/61) (launch packet doc) §1.5 for the full list of URL fields needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)