### PR TITLE
Privacy policy: expand section 8 into proper account-deletion + retention

### DIFF
--- a/src/pages/privacy-policy/index.tsx
+++ b/src/pages/privacy-policy/index.tsx
@@ -163,20 +163,93 @@ const PrivacyPolicyPage: React.FC = () => {
               <ul className="list-disc list-inside text-white/70 space-y-2 ml-4">
                 <li>Access and review your personal information</li>
                 <li>Request correction of inaccurate data</li>
-                <li>Delete your account and associated data</li>
+                <li>
+                  <a
+                    href="#account-deletion"
+                    className="underline hover:text-white"
+                  >
+                    Delete your account and associated data
+                  </a>
+                </li>
                 <li>Opt-out of non-essential communications</li>
                 <li>Control location data sharing</li>
               </ul>
             </div>
 
             <div className="space-y-4">
-              <h3 className="text-md font-semibold text-white">
-                8. Data Retention
+              <h3
+                id="account-deletion"
+                className="text-md font-semibold text-white scroll-mt-24"
+              >
+                8. Account Deletion and Data Retention
               </h3>
               <p className="text-white/70 leading-relaxed">
-                We retain your information only as long as necessary to provide
-                our services and comply with legal obligations. You can request
-                data deletion at any time.
+                You can delete your Lishka account at any time. Deleting your
+                account permanently removes the personal data Lishka holds
+                about you from our active systems.
+              </p>
+
+              <h4 className="font-medium text-white">
+                How to delete your account
+              </h4>
+              <p className="text-white/70 leading-relaxed">
+                <strong>From the Lishka app:</strong> open the{" "}
+                <strong>Profile</strong> tab → tap the{" "}
+                <strong>menu icon</strong> (top right) → tap{" "}
+                <strong>&quot;Delete Account&quot;</strong> → confirm. Your
+                account is deleted immediately and you are signed out.
+              </p>
+              <p className="text-white/70 leading-relaxed">
+                <strong>By email:</strong> if you no longer have access to the
+                app, email{" "}
+                <a
+                  href="mailto:tonnaclayton@gmail.com"
+                  className="underline hover:text-white"
+                >
+                  tonnaclayton@gmail.com
+                </a>{" "}
+                from the address linked to your Lishka account, with the
+                subject &quot;Delete my account&quot;. We action requests
+                within 7 days.
+              </p>
+
+              <h4 className="font-medium text-white">What gets deleted</h4>
+              <ul className="list-disc list-inside text-white/70 space-y-2 ml-4">
+                <li>
+                  Your profile (email, name, location, fishing experience,
+                  preferences)
+                </li>
+                <li>
+                  Your photo gallery and uploaded catch photos
+                </li>
+                <li>Logged catches and catch metadata</li>
+                <li>Saved fishing locations</li>
+                <li>Push notification token</li>
+                <li>Your Ask Lishka chat history</li>
+              </ul>
+
+              <h4 className="font-medium text-white">
+                What is retained, and for how long
+              </h4>
+              <p className="text-white/70 leading-relaxed">
+                Encrypted backups maintained by our infrastructure providers
+                hold copies of database state for up to 30 days for disaster
+                recovery. Backups containing your data are purged on the
+                standard rotation within 30 days of your deletion request.
+              </p>
+              <p className="text-white/70 leading-relaxed">
+                Anonymised aggregate analytics (e.g. counts of how many users
+                opened a screen on a given day) are retained indefinitely.
+                After your account is deleted these events contain no personal
+                identifiers and cannot be re-associated with you.
+              </p>
+
+              <h4 className="font-medium text-white">
+                Re-creating an account after deletion
+              </h4>
+              <p className="text-white/70 leading-relaxed">
+                If you sign up again with the same email after deletion, a
+                fresh account is created — none of your prior data is restored.
               </p>
             </div>
 
@@ -229,9 +302,24 @@ const PrivacyPolicyPage: React.FC = () => {
                 11. Contact Us
               </h3>
               <p className="text-white/70 leading-relaxed">
-                If you have questions about this Privacy Policy or how we handle
-                your data, please contact us through our Instagram @lishka.app
-                or through the contact options in the App.
+                If you have questions about this Privacy Policy or how we
+                handle your data, you can reach us by email at{" "}
+                <a
+                  href="mailto:tonnaclayton@gmail.com"
+                  className="underline hover:text-white"
+                >
+                  tonnaclayton@gmail.com
+                </a>
+                , through our Instagram{" "}
+                <a
+                  href="https://instagram.com/lishka.app"
+                  className="underline hover:text-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  @lishka.app
+                </a>
+                , or through the contact options in the App.
               </p>
             </div>
 


### PR DESCRIPTION
**Required for Play Store data-safety review.** Same compliance applies to App Store too, so this also pre-empts any future Apple re-review.

## Why
The existing section 8 ("Data Retention") is one sentence: *"We retain your information only as long as necessary…you can request data deletion at any time."* That's enough for Apple, but Google's Data Safety form on Play Console requires the deletion link to prominently:

1. Refer to the app or developer name (Lishka ✓)
2. **Show the steps users should take to delete the account** (was missing)
3. **List the types of data that are deleted or kept, plus any retention period** (was missing)

Without all three, the Play Store first submission gets bounced.

## What changed

| Section | Change |
|---|---|
| 7. Your Rights — third bullet | Now an anchored link `#account-deletion` so the bullet is actionable |
| 8. Data Retention → **Account Deletion and Data Retention** | Expanded to four sub-sections: how to delete (in-app path + email fallback), what gets deleted (named data categories), what is retained (encrypted backups ≤30d; anonymised analytics indefinitely with no identifiers), re-creating an account |
| 8. heading | Now carries `id=\"account-deletion\"` + `scroll-mt-24` so deep links land scrolled to the section, not behind the sticky header |
| 11. Contact Us | Adds an email address. Previously Instagram-only; that doesn't satisfy Play Store's named-contact-channel expectation (or GDPR) |

No renumbering — section 8 keeps its number; 9 / 10 / 11 untouched.

## URL the Play Console form needs

\`https://www.lishka.app/privacy-policy#account-deletion\`

## Test plan
- [ ] Open the published page in a browser. Hit Cmd+F for \"Account Deletion\" — section appears.
- [ ] Paste the deep-link URL with #account-deletion in the address bar — page scrolls to the section, not behind the sticky header.
- [ ] Click the section 7 link \"Delete your account and associated data\" — same scroll behavior.
- [ ] Click the email mailto links — opens mail composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)