### PR TITLE
Privacy policy: apply prettier formatting (unblocks Vercel deploy)

### DIFF
--- a/src/pages/privacy-policy/index.tsx
+++ b/src/pages/privacy-policy/index.tsx
@@ -185,8 +185,8 @@ const PrivacyPolicyPage: React.FC = () => {
               </h3>
               <p className="text-white/70 leading-relaxed">
                 You can delete your Lishka account at any time. Deleting your
-                account permanently removes the personal data Lishka holds
-                about you from our active systems.
+                account permanently removes the personal data Lishka holds about
+                you from our active systems.
               </p>
 
               <h4 className="font-medium text-white">
@@ -208,9 +208,8 @@ const PrivacyPolicyPage: React.FC = () => {
                 >
                   tonnaclayton@gmail.com
                 </a>{" "}
-                from the address linked to your Lishka account, with the
-                subject &quot;Delete my account&quot;. We action requests
-                within 7 days.
+                from the address linked to your Lishka account, with the subject
+                &quot;Delete my account&quot;. We action requests within 7 days.
               </p>
 
               <h4 className="font-medium text-white">What gets deleted</h4>
@@ -219,9 +218,7 @@ const PrivacyPolicyPage: React.FC = () => {
                   Your profile (email, name, location, fishing experience,
                   preferences)
                 </li>
-                <li>
-                  Your photo gallery and uploaded catch photos
-                </li>
+                <li>Your photo gallery and uploaded catch photos</li>
                 <li>Logged catches and catch metadata</li>
                 <li>Saved fishing locations</li>
                 <li>Push notification token</li>
@@ -239,8 +236,8 @@ const PrivacyPolicyPage: React.FC = () => {
               </p>
               <p className="text-white/70 leading-relaxed">
                 Anonymised aggregate analytics (e.g. counts of how many users
-                opened a screen on a given day) are retained indefinitely.
-                After your account is deleted these events contain no personal
+                opened a screen on a given day) are retained indefinitely. After
+                your account is deleted these events contain no personal
                 identifiers and cannot be re-associated with you.
               </p>
 
@@ -248,8 +245,8 @@ const PrivacyPolicyPage: React.FC = () => {
                 Re-creating an account after deletion
               </h4>
               <p className="text-white/70 leading-relaxed">
-                If you sign up again with the same email after deletion, a
-                fresh account is created — none of your prior data is restored.
+                If you sign up again with the same email after deletion, a fresh
+                account is created — none of your prior data is restored.
               </p>
             </div>
 
@@ -302,8 +299,8 @@ const PrivacyPolicyPage: React.FC = () => {
                 11. Contact Us
               </h3>
               <p className="text-white/70 leading-relaxed">
-                If you have questions about this Privacy Policy or how we
-                handle your data, you can reach us by email at{" "}
+                If you have questions about this Privacy Policy or how we handle
+                your data, you can reach us by email at{" "}
                 <a
                   href="mailto:tonnaclayton@gmail.com"
                   className="underline hover:text-white"


### PR DESCRIPTION
**Unblocks the Vercel deploy from #127.**

The Code Quality & Testing CI step on `cdfa321` (the #127 merge commit) failed because the new account-deletion section in `privacy-policy/index.tsx` was committed without running the project's prettier rules over it. Depending on how the Vercel deploy job is wired to CI, that may have blocked the production deploy — the live page at lishka.app/privacy-policy still serves the pre-merge bundle (\`index-Uwa4ezut.js\`), and the deep link \`#account-deletion\` doesn't resolve to a section yet.

This PR is purely a `prettier --write` pass on the file. No JSX changes, no copy changes — just whitespace and line breaks adjusted to match the project's prettier config. `npm run format:check` passes locally after the change.

## Why this matters right now
The deep-link URL is referenced from the Play Console Data Safety form (\`https://www.lishka.app/privacy-policy#account-deletion\`). Until Vercel deploys the merged content, that link lands on an un-anchored privacy policy. Once this PR merges, Vercel should rebuild and the anchor will start working.

## Test plan
- [x] `npm run format:check` passes locally
- [ ] After merge: Vercel deploys, lishka.app/privacy-policy serves the new bundle, deep link scrolls to "Account Deletion and Data Retention" heading

🤖 Generated with Claude Code