### PR TITLE
Install Meta Pixel + track primary CTA as Lead event

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,58 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+
+    <!-- Meta Pixel — gated to non-localhost hosts so dev work doesn't
+         pollute production analytics. Pixel ID is public by design
+         (it's transmitted in every event the browser sends, so
+         keeping it out of source code wouldn't hide it). Custom
+         events fire from `src/lib/meta-pixel.ts`; this snippet just
+         loads the library and logs the auto-PageView. -->
+    <script>
+      (function () {
+        if (
+          location.hostname === "localhost" ||
+          location.hostname === "127.0.0.1"
+        ) {
+          // Stub out fbq so calls from app code don't throw in dev.
+          window.fbq = function () {};
+          return;
+        }
+        !(function (f, b, e, v, n, t, s) {
+          if (f.fbq) return;
+          n = f.fbq = function () {
+            n.callMethod
+              ? n.callMethod.apply(n, arguments)
+              : n.queue.push(arguments);
+          };
+          if (!f._fbq) f._fbq = n;
+          n.push = n;
+          n.loaded = !0;
+          n.version = "2.0";
+          n.queue = [];
+          t = b.createElement(e);
+          t.async = !0;
+          t.src = v;
+          s = b.getElementsByTagName(e)[0];
+          s.parentNode.insertBefore(t, s);
+        })(
+          window,
+          document,
+          "script",
+          "https://connect.facebook.net/en_US/fbevents.js",
+        );
+        fbq("init", "1301918371549325");
+        fbq("track", "PageView");
+      })();
+    </script>
+    <noscript
+      ><img
+        height="1"
+        width="1"
+        style="display: none"
+        src="https://www.facebook.com/tr?id=1301918371549325&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel -->
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -82,16 +82,25 @@
         fbq("track", "PageView");
       })();
     </script>
-    <noscript
-      ><img
+    <!-- End Meta Pixel -->
+  </head>
+  <body>
+    <!-- Meta Pixel <noscript> fallback. HTML5 forbids <img> inside a
+         <head>-level <noscript> (only <link>/<style>/<meta> are
+         allowed there per the spec, and parse5 — used by Vite's PWA
+         plugin — enforces this). Stock browsers tolerate the
+         <head> form, but the build doesn't. So this lives in
+         <body> as the spec requires while still giving us the
+         no-JS fallback tracking ping. -->
+    <noscript>
+      <img
         height="1"
         width="1"
         style="display: none"
         src="https://www.facebook.com/tr?id=1301918371549325&ev=PageView&noscript=1"
-    /></noscript>
-    <!-- End Meta Pixel -->
-  </head>
-  <body>
+        alt=""
+      />
+    </noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
     <!-- <script src="https://api.tempo.build/proxy-asset?url=https://storage.googleapis.com/tempo-public-assets/error-handling.js"></script> [deprecated] -->

--- a/src/lib/meta-pixel.ts
+++ b/src/lib/meta-pixel.ts
@@ -1,0 +1,71 @@
+// ────────────────────────────────────────────────────────────────────────────
+// Meta Pixel — typed helpers for the standard / custom events we fire from
+// landing-page code. The Pixel itself is initialised in `index.html`
+// (synchronous, before React hydrates) so the auto `PageView` fires on every
+// route load including the initial paint. This module is for the events
+// we trigger from app code: `Lead` on the primary CTA, etc.
+//
+// The library is loaded lazily into `window.fbq` by Meta's standard
+// snippet. In development we stub it to a no-op so calls from React
+// components don't throw when the snippet is gated out (see index.html).
+//
+// Event taxonomy:
+//   - `PageView`      — automatic on every page load (index.html)
+//   - `Lead`          — user clicked the primary "Get Started" CTA
+//                       (current funnel: landing → login flow)
+//   - When App Store / Play Store badges land on the landing page,
+//     add `trackAppDownloadIntent(platform)` calls below.
+// ────────────────────────────────────────────────────────────────────────────
+
+declare global {
+  interface Window {
+    fbq?: (
+      action: "track" | "trackCustom" | "init",
+      event: string,
+      params?: Record<string, unknown>,
+    ) => void;
+  }
+}
+
+/** Safe `fbq(...)` call. No-op when the snippet is stubbed (dev mode) or
+ *  the library hasn't loaded yet (network failure, ad-blocker). */
+function fbq(
+  action: "track" | "trackCustom",
+  event: string,
+  params?: Record<string, unknown>,
+): void {
+  if (typeof window === "undefined") return;
+  if (typeof window.fbq !== "function") return;
+  try {
+    window.fbq(action, event, params);
+  } catch {
+    // Swallowed — tracking failures must never break the page.
+  }
+}
+
+/**
+ * Fire the standard `Lead` event when a visitor commits to the primary
+ * conversion (clicking "Get Started" on the landing page). Meta's
+ * algorithm understands the standard `Lead` event natively, which
+ * makes it the best event to optimise paid campaigns against.
+ *
+ * The `content_name` parameter lets us tell the two future variants
+ * apart in Events Manager — "Get Started → login" today, and once App
+ * Store / Play Store badges ship, "iOS download" / "Android download".
+ */
+export function trackLead(contentName: string): void {
+  fbq("track", "Lead", { content_name: contentName });
+}
+
+/**
+ * Fire when a visitor taps an App Store / Play Store badge on the
+ * landing page. Logged as `Lead` with a platform-specific
+ * `content_name` so both can be optimised together but inspected
+ * separately. Wire this on the badges once they ship.
+ */
+export function trackAppDownloadIntent(platform: "ios" | "android"): void {
+  fbq("track", "Lead", {
+    content_name: platform === "ios" ? "iOS download" : "Android download",
+    content_category: "App download",
+  });
+}

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -16,6 +16,7 @@ import Autoplay from "embla-carousel-autoplay";
 import { cn } from "@/lib/utils";
 import { Link } from "react-router-dom";
 import { ROUTES } from "@/lib/routing";
+import { trackLead } from "@/lib/meta-pixel";
 import LandingPageLayout, {
   LandingPageHeader,
 } from "@/components/layout/landing-page-layout";
@@ -195,6 +196,7 @@ export default function LandingPage() {
             {/* CTA Button with glow effect */}
             <Link
               to={ROUTES.LOGIN}
+              onClick={() => trackLead("Get Started")}
               className="bg-[#0251FB] hover:bg-blue-600 text-white px-8 py-4 rounded-full font-medium shadow-lg mx-auto text-base transition-all duration-300 hover:shadow-[0_0_20px_rgba(2,81,251,0.6),0_0_40px_rgba(2,81,251,0.4),0_0_60px_rgba(2,81,251,0.2)] hover:scale-105 lg:text-lg"
             >
               <span>Get Started</span>


### PR DESCRIPTION
**Marketing infrastructure.** Vercel auto-deploy on merge.

## What
- Pixel ID `1301918371549325` (the "Lishka Web" dataset created today in Meta Events Manager) installed synchronously in `index.html`. Auto-`PageView` fires on every page load, including the initial paint before React hydrates.
- New `src/lib/meta-pixel.ts` — typed wrapper for the events we fire from React. Two helpers today: `trackLead` and `trackAppDownloadIntent`.
- Landing-page hero CTA ("Get Started") now fires `Lead` with `content_name: "Get Started"`. That's the event Meta ad campaigns will optimise against.

## Why now
Pixel data takes 24–48 hours to start producing useful patterns and weeks to optimise paid campaigns against. Better to install before running the next ad batch than after.

## What's NOT in here
- **Conversions API** (server-side event mirroring). The Meta dataset is configured to *support* CAPI — we just haven't written the server-side code yet. Worth doing once the user starts spending real money on Meta. Stays a separate PR.
- **App download tracking on landing-page badges.** The landing page doesn't have App Store / Play Store badges yet (only a single "Get Started" CTA that routes to login). When those badges ship, wire `trackAppDownloadIntent('ios')` / `trackAppDownloadIntent('android')` on them — helper already in place.
- **Mobile App Events SDK.** Separate piece of work, requires a new native build on both platforms (see earlier conversation). Defer until paid acquisition is actually running.

## Dev hygiene
- Pixel only fires on non-localhost hosts. Local dev (`vite dev`) won't pollute production stats.
- `window.fbq` is stubbed in dev mode so calls from app code don't throw if the snippet was skipped.
- `meta-pixel.ts` swallows fbq exceptions — tracking failures must never break the page.

## Pixel ID handling
The Pixel ID is hardcoded into `index.html` rather than read from an env var because:
1. The ID is public by design — it's transmitted in every event from every browser, so source-code obfuscation buys nothing.
2. Vite's HTML transform makes env var substitution into `index.html` awkward; the simpler hardcode is more transparent.

## Test plan
- [x] Typecheck passes
- [x] Prettier passes
- [ ] After Vercel deploy: install Meta Pixel Helper Chrome extension, browse to lishka.app, confirm PageView fires
- [ ] Click "Get Started" CTA → Pixel Helper shows Lead event with `content_name: "Get Started"`
- [ ] Check Meta Events Manager → "Test events" tab. Real-time stream of fired events.

🤖 Generated with Claude Code